### PR TITLE
can handle reference-style image syntax now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site
 nbproject/private
 profiles.xml
 target
+tags


### PR DESCRIPTION
Reference-style image syntax looks like this:

```
![Alt text][id]
```

Where “id” is the name of a defined image reference. Image references are defined using syntax identical to link references:

```
[id]: url/to/image  "Optional title attribute"
```
